### PR TITLE
fix(segfault)

### DIFF
--- a/apache_exporter.go
+++ b/apache_exporter.go
@@ -132,7 +132,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 func (e *Exporter) scrape(ch chan<- prometheus.Metric) error {
 	html, err := goquery.NewDocument(e.URI)
 	if err != nil {
-		log.Errorf("Scrape Apache Server Status Error: ", err)
+		return fmt.Errorf("Scrape Apache Server Status Error: %v", err)
 	}
 
 	var minVersion string


### PR DESCRIPTION
exporter tends to crash with following message:

```
time="2019-06-23T08:08:11Z" level=info msg="Starting Server: :9113" file=apache_exporter.go line=282
time="2019-06-23T08:08:11Z" level=info msg="Scraping URL: http://stats:8081/server-status" file=apache_exporter.go line=283
time="2019-06-23T10:24:28Z" level=error msg="Scrape Apache Server Status Error: %!(EXTRA *url.Error=Get http://stats:8081/server-status: EOF)" file=apache_exporter.go line=135
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6bd4d3]

goroutine 29484 [running]:
main.(*Exporter).scrape(0xc42007d450, 0xc4205dacc0, 0xc42007d460, 0xc400000008)
	/go/src/github.com/tanner-bruce/apache_exporter/apache_exporter.go:140 +0xd3
main.(*Exporter).Collect(0xc42007d450, 0xc4205dacc0)
	/go/src/github.com/tanner-bruce/apache_exporter/apache_exporter.go:242 +0x7c
github.com/tanner-bruce/apache_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func2(0xc420018f40, 0xc4205dacc0, 0x925a80, 0xc42007d450)
	/go/src/github.com/tanner-bruce/apache_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:433 +0x61
created by github.com/tanner-bruce/apache_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/src/github.com/tanner-bruce/apache_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:431 +0x2e1
```